### PR TITLE
checks for undefined

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -91,6 +91,8 @@ function getNameFromRef(ref) {
 }
 
 function convertType(swaggerType, swagger) {
+  swagger = swagger || {};
+  
   var typespec = {
     description: swaggerType.description,
     simpleFlowType: undefined,

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -14,6 +14,7 @@ var _ = require('lodash');
 function convertType(swaggerType, swagger) {
   // sanitize input
   swaggerType = swaggerType || {};
+  swagger = swagger || {};
 
   var typespec = { description: swaggerType.description, isEnum: false };
 


### PR DESCRIPTION
Avoid problems with `swagger` coming as `undefined` when generating services coming from openapi3 specs converted to swagger2 